### PR TITLE
Activate Email API Call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2871,7 +2871,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3236,7 +3237,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3284,6 +3286,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3322,11 +3325,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -6544,7 +6549,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6562,11 +6568,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6579,15 +6587,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6690,7 +6701,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6700,6 +6712,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6712,17 +6725,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6739,6 +6755,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6811,7 +6828,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6821,6 +6839,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6896,7 +6915,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6926,6 +6946,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6943,6 +6964,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6981,11 +7003,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/src/App.react.js
+++ b/src/App.react.js
@@ -11,6 +11,7 @@ import ChangePasswordPage from './components/profile/ChangePasswordPage.react'
 import TopUpPage from './components/topup/TopUpPage.react'
 import LogoutPage from './components/profile/LogoutPage.react'
 import TagOnPage from './components/tagon/TagOnPage.react'
+import ConfirmEmail from './components/register/ConfirmEmail.react'
 
 function App() {
 	return (
@@ -26,6 +27,7 @@ function App() {
 					<Route exact path="/topup" component={TopUpPage} />
 					<Route exact path="/logout" component={LogoutPage} />
 					<Route exact path="/tagon" component={TagOnPage} />
+					<Route path="/verify/:id" component={ConfirmEmail}/>
 				</Switch>
 			</Router>
 		</React.StrictMode>

--- a/src/components/register/ConfirmEmail.react.js
+++ b/src/components/register/ConfirmEmail.react.js
@@ -1,0 +1,46 @@
+import React, { Component } from 'react'
+import API from '../../utils/API'
+import { Page, Grid, Alert, Form as TablerForm, Button } from 'tabler-react'
+
+class ConfirmEmail extends Component {
+	constructor(props) {
+		super(props)
+		this.state = { message: 'Activating your account...' }
+	}
+
+	componentDidMount() {
+		// Get Verification ID from URL
+		const verification = {
+			id: this.props.match.params.id
+		}
+
+		// Call Database to Verify
+		API.post('/verify', verification)
+			.then(result => {
+				// Redirect on Success
+				this.setState({ message: 'Account Activated! Redirecting to login...' })
+				this.props.history.push('/login')
+			})
+			.catch(error => {
+				// Already Done? or Not Found?
+				if (error.response && error.response.status == 404) {
+					this.setState({
+						message:
+							'Unable to Activate User. You only have to confirm it once.'
+					})
+					this.props.history.push('/login')
+				}
+				this.setState({ message: 'Unable to Activate User.' })
+			})
+	}
+
+	render() {
+		return (
+			<Page.Content>
+				<h4>{this.state.message}</h4>
+			</Page.Content>
+		)
+	}
+}
+
+export default ConfirmEmail

--- a/src/utils/API.js
+++ b/src/utils/API.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 export default axios.create({
-	baseURL: 'http://localhost:3000',
+	baseURL: 'http://192.168.1.68:3000',
 	responseType: 'json',
 	headers: { Authorization: `Bearer ${localStorage.getItem('token') || ''}` }
 })


### PR DESCRIPTION
A user who has received an email to activate their account is now able to click the button in the email and is taken to the front-end component responsible for making the API call to verify the account's email.
-  In Production, the URLs (such as the Axios endpoint at front-end and `FRONT_END_URL` in `.env` must be pointing to the URL/IP (not localhost), for it to work.
-  If API returns OK, the user is redirected to `/login` route, else an error message is displayed and they are then (still) redirected to `/login` route.
